### PR TITLE
Fix v2 Downgrade function

### DIFF
--- a/v2/tests/migrations_test.go
+++ b/v2/tests/migrations_test.go
@@ -318,12 +318,16 @@ func migrate(revision int) error {
 
 // Clean out the database.
 func clean(t *testing.T) {
-	if _, err := conn.Exec("delete from migrations.applied"); err != nil {
-		t.Fatalf("Unable to clear the migrations.applied table: %s", err)
+	if err := tableExists("migrations.applied"); err == nil {
+		if _, err := conn.Exec("delete from migrations.applied"); err != nil {
+			t.Fatalf("Unable to clear the migrations.applied table: %s", err)
+		}
 	}
 
-	if _, err := conn.Exec("delete from migrations.rollbacks"); err != nil {
-		t.Fatalf("Unable to clear the migrations.rollbacks table: %s", err)
+	if err := tableExists("migrations.rollbacks"); err == nil {
+		if _, err := conn.Exec("delete from migrations.rollbacks"); err != nil {
+			t.Fatalf("Unable to clear the migrations.rollbacks table: %s", err)
+		}
 	}
 
 	rows, err := conn.Query("select table_name from information_schema.tables where table_schema='public'")

--- a/v2/tests/upgrade_test.go
+++ b/v2/tests/upgrade_test.go
@@ -54,16 +54,7 @@ func TestUpgrade(t *testing.T) {
 	}
 
 	// Upgrade to V2
-	tx, err := conn.Begin()
-	if err != nil {
-		t.Fatalf("Failed to create a transaction: %s", err)
-	}
-
-	if err := v2.Upgrade(tx, "./sql_upgrade"); err != nil {
-		t.Errorf("Failed to upgrade database to v2: %s", err)
-	}
-
-	if err := tx.Commit(); err != nil {
+	if err := v2.InitializeDB(conn, ".sql_upgrade"); err != nil {
 		t.Fatalf("Failed upgrade database: %s", err)
 	}
 
@@ -125,4 +116,153 @@ func TestUpgrade(t *testing.T) {
 	if err := migrationApplied("3-alter-users.sql"); err == nil {
 		t.Error("Migration 3-alter-users.sql remains")
 	}
+}
+
+// Can we downgrade from migrations v2 to v1?
+func TestDowngrade(t *testing.T) {
+	defer clean(t)
+
+	// V1 Migration
+	if err := v1.Migrate(conn, "./sql_upgrade", 2); err != nil {
+		t.Fatalf("Unable to run v1 migrations: %s", err)
+	}
+
+	if err := tableExists("schema_migrations"); err != nil {
+		t.Fatal("The schema_migrations table wasn't created")
+	}
+
+	if err := tableExists("users"); err != nil {
+		t.Fatal("Users table not found in database")
+	}
+
+	if err := tableExists("roles"); err != nil {
+		t.Fatal("Roles table not found in database")
+	}
+
+	if _, err := conn.Exec("insert into users (email, username) values ('jdoe@nowhere.com', 'jdoe')"); err != nil {
+		t.Errorf("Unable to insert record into users: %s", err)
+	}
+
+	rows, err := conn.Query("select email from users where username = 'jdoe'")
+	if err != nil {
+		t.Errorf("Didn't find expected record in database: %s", err)
+	}
+
+	var email string
+	for rows.Next() {
+		if err := rows.Scan(&email); err != nil {
+			t.Errorf("Failed to get email from database: %s", err)
+		}
+
+		if email != "jdoe@nowhere.com" {
+			t.Errorf("Expected name jdoe@nowhere.com, got %s", email)
+		}
+	}
+
+	if email == "" {
+		t.Error("Email not found")
+	}
+
+	// Upgrade to V2
+	if err := v2.InitializeDB(conn, ".sql_upgrade"); err != nil {
+		t.Fatalf("Failed upgrade database: %s", err)
+	}
+
+	// Did it work?
+	if err := tableExists("migrations.applied"); err != nil {
+		t.Error("Migrations applied table not found in database")
+	}
+
+	if err := tableExists("migrations.rollbacks"); err != nil {
+		t.Error("Migrations applied table not found in database")
+	}
+
+	if err := tableExists("schema_migrations"); err == nil {
+		t.Error("The schema_migrations table was found in database; should have been removed")
+	}
+
+	if err := migrationApplied("1-create-users.sql"); err != nil {
+		t.Error("Did not migration 1-create-users.sql")
+	}
+
+	if err := migrationApplied("2-create-roles.sql"); err != nil {
+		t.Error("Did not migration 1-create-roles.sql")
+	}
+
+	if err := migrationApplied("3-alter-users.sql"); err == nil {
+		t.Error("Migration 3-alter-users.sql was prematurely applied")
+	}
+
+	if err := v2.WithDirectory("./sql_upgrade").Apply(conn); err != nil {
+		t.Errorf("Failed to run v2 migrations: %s", err)
+	}
+
+	if err := migrationApplied("3-alter-users.sql"); err != nil {
+		t.Error("Did not migrate 3-alter-users.sql")
+	}
+
+	// Downgrade back to v1
+	err = v2.Downgrade(conn)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if err := tableExists("migrations.applied"); err == nil {
+		t.Error("Migrations applied table not found in database")
+	}
+
+	if err := tableExists("migrations.rollbacks"); err == nil {
+		t.Error("Migrations applied table not found in database")
+	}
+
+	if err := tableExists("schema_migrations"); err != nil {
+		t.Fatal("The schema_migrations table wasn't created")
+	}
+
+	if err := tableExists("users"); err != nil {
+		t.Fatal("Users table not found in database")
+	}
+
+	if err := tableExists("roles"); err != nil {
+		t.Fatal("Roles table not found in database")
+	}
+
+	if _, err := conn.Exec("insert into users (email, username, age) values ('bob@nowhere.com', 'bob', 99)"); err != nil {
+		t.Errorf("Unable to insert record into users: %s", err)
+	}
+
+	rows, err = conn.Query("select email from users where username = 'bob'")
+	if err != nil {
+		t.Errorf("Didn't find expected record in database: %s", err)
+	}
+
+	for rows.Next() {
+		if err := rows.Scan(&email); err != nil {
+			t.Errorf("Failed to get email from database: %s", err)
+		}
+
+		if email != "bob@nowhere.com" {
+			t.Errorf("Expected name bob@nowhere.com, got %s", email)
+		}
+	}
+
+	if email == "" {
+		t.Error("Email not found")
+	}
+
+	// See if a v1 rollback works
+	if err := v1.Rollback(conn, "./sql_upgrade", 2); err != nil {
+		t.Fatalf("Unable to rollback migration to revision 1: %s", err)
+	}
+
+	_, err = conn.Query("select name from roles where name = 'Empty'")
+	if err == nil {
+		t.Error("Expected querying for the rolled-back table to fail")
+	}
+
+	_, err = conn.Query("select age from users where name = 'Bob'")
+	if err == nil {
+		t.Error("Expected querying for the rolled-back column to fail")
+	}
+
 }

--- a/v2/upgrade.go
+++ b/v2/upgrade.go
@@ -48,8 +48,8 @@ func Downgrade(db *sql.DB) error {
 		return tx.Commit()
 	}
 
-	if _, err := tx.Exec("insert into schema_migrations(migration) " +
-		"select migration from migrations.applied on conflict migration do nothing"); err != nil {
+	if _, err := tx.Exec("insert into schema_migrations (migration) " +
+		"(select migration from migrations.applied) on conflict (migration) do nothing"); err != nil {
 		_ = tx.Rollback()
 		return err
 	}


### PR DESCRIPTION
- Fix `v2.Downgrade()` function in `v2/upgrade.go` which fails with `ERROR: syntax error at or near \"migration\" (SQLSTATE 42601)` 

- Change tests in `v2/tests/upgrade_test.go` to allow them to run on their own or out of order or after failures in other tests. 
    - Change `v2.Upgrade` calls to `v2.InitializeDB.` 
    - If this test is run on its own, or without running tests in `embedded_test.go` first, the `Apply()` or `InitializeDB()` functions are never run, and the migrations tables are never created.

- Change `clean()` function in `v2/tests/migrations_test.go` to not delete from tables which might not exist.


Tested with Postgres version 15.4.